### PR TITLE
Fixed oclif module not found errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,5 +121,6 @@ dist
 /lib
 /tmp
 
-
+# IDE
 .idea
+.vscode

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
+    "@oclif/errors": "^1.3.6",
+    "@oclif/parser": "^3.8.17",
     "@oclif/plugin-help": "^3",
     "exiftool-vendored": "^12.1.0",
     "tslib": "^1"


### PR DESCRIPTION
This PR involves adding `@oclif/errors` & `@oclif/parser` package which fixes the following errors.

```
/home/xnehaxixh/Work/Scripts/google-photos-exif/node_modules/.pnpm/ts-node@8.10.2_typescript@3.9.10/node_modules/ts-node/src/index.ts:434
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/index.ts:2:25 - error TS2307: Cannot find module '@oclif/parser' or its corresponding type declarations.

2 import * as Parser from '@oclif/parser';
                          ~~~~~~~~~~~~~~~

    at createTSError (/home/xnehaxixh/Work/Scripts/google-photos-exif/node_modules/.pnpm/ts-node@8.10.2_typescript@3.9.10/node_modules/ts-node/src/index.ts:434:12)
    at reportTSError (/home/xnehaxixh/Work/Scripts/google-photos-exif/node_modules/.pnpm/ts-node@8.10.2_typescript@3.9.10/node_modules/ts-node/src/index.ts:438:19)
    at getOutput (/home/xnehaxixh/Work/Scripts/google-photos-exif/node_modules/.pnpm/ts-node@8.10.2_typescript@3.9.10/node_modules/ts-node/src/index.ts:578:36)
    at Object.compile (/home/xnehaxixh/Work/Scripts/google-photos-exif/node_modules/.pnpm/ts-node@8.10.2_typescript@3.9.10/node_modules/ts-node/src/index.ts:775:32)
    at Module.m._compile (/home/xnehaxixh/Work/Scripts/google-photos-exif/node_modules/.pnpm/ts-node@8.10.2_typescript@3.9.10/node_modules/ts-node/src/index.ts:858:43)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Object.require.extensions.<computed> [as .ts] (/home/xnehaxixh/Work/Scripts/google-photos-exif/node_modules/.pnpm/ts-node@8.10.2_typescript@3.9.10/node_modules/ts-node/src/index.ts:861:12)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Function.Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
 ELIFECYCLE  Command failed with exit code 1.
```

```
Error: Cannot find module '@oclif/errors/handle'
Require stack:
- /home/xnehaxixh/Work/Scripts/google-photos-exif/bin/run
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Function.Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/home/xnehaxixh/Work/Scripts/google-photos-exif/bin/run:13:8)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Function.Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
 ELIFECYCLE  Command failed with exit code 1.
```

The script can be run now without any errors.